### PR TITLE
authorizePayment after verification using RPay's Payment API

### DIFF
--- a/src/api/routes/hooks/index.js
+++ b/src/api/routes/hooks/index.js
@@ -10,7 +10,11 @@ export default (app) => {
     route.post(
         "/hooks",
         // razorpay constructEvent fails without body-parser
-        bodyParser.raw({ type: "application/json" }),
+        bodyParser.json({
+            verify: (req, res, buf) => {
+              req.rawBody = buf;
+            },
+          }),
         middlewares.wrap(require("./razorpay").default)
     );
     return app;

--- a/src/api/routes/hooks/razorpay.js
+++ b/src/api/routes/hooks/razorpay.js
@@ -1,8 +1,6 @@
 import { validateWebhookSignature } from "razorpay"
 
 export default async (req, res) => {
-  //console.log('razorpay wh req.rawBody', req.rawBody);
-  //console.log('razorpay wh req.body', req.body);
 
   const webhookSignature = req.headers["x-razorpay-signature"];
 
@@ -23,9 +21,6 @@ export default async (req, res) => {
   const orderService = req.scope.resolve("orderService");
 
   const order = await orderService.retrieveByCartId(cartId).catch(() => undefined);
-
-  // console.log('event', event);
-  // console.log('order', order);
 
   switch (event) {
     // payment authorization is handled in checkout flow. webhook not needed
@@ -58,65 +53,3 @@ export default async (req, res) => {
 
   res.sendStatus(200);
 };
-
-
-// req.body = {
-//   entity: 'event',
-//   account_id: 'acc_LRKR9N2gBC0ezZ',
-//   event: 'payment.authorized',
-//   contains: ['payment'],
-//   payload: {
-//     payment: {
-//       entity: {
-//         id: 'pay_LUahpVBO47saCl',
-//         entity: 'payment',
-//         amount: 214900,
-//         currency: 'INR',
-//         status: 'authorized',
-//         order_id: 'order_LUahZlqYrBboBZ',
-//         invoice_id: null,
-//         international: false,
-//         method: 'card',
-//         amount_refunded: 0,
-//         refund_status: null,
-//         captured: false,
-//         description: 'Order No: order_LUahZlqYrBboBZ',
-//         card_id: 'card_LUahpYeDtgqVRI',
-//         card: {
-//           id: 'card_LUahpYeDtgqVRI',
-//           entity: 'card',
-//           name: '',
-//           last4: '5449',
-//           network: 'MasterCard',
-//           type: 'credit',
-//           issuer: 'UTIB',
-//           international: false,
-//           emi: false,
-//           sub_type: 'consumer',
-//           token_iin: null,
-//         },
-//         bank: null,
-//         wallet: null,
-//         vpa: null,
-//         email: 'abc@xyz.com',
-//         contact: '+91XXXXXXXXXX',
-//         notes: {
-//           cart_id: 'cart_01GW4S0F9KQK414ZEFH4NTNYJV',
-//           customer: 'cust_LRQCbsXDFTy0Mk',
-//         },
-//         fee: null,
-//         tax: null,
-//         error_code: null,
-//         error_description: null,
-//         error_source: null,
-//         error_step: null,
-//         error_reason: null,
-//         acquirer_data: {
-//           auth_code: '377689',
-//         },
-//         created_at: 1679492688,
-//       },
-//     },
-//   },
-//   created_at: 1679492691,
-// }

--- a/src/api/routes/hooks/razorpay.js
+++ b/src/api/routes/hooks/razorpay.js
@@ -1,56 +1,122 @@
+import { validateWebhookSignature } from "razorpay"
+
 export default async (req, res) => {
-    const signature = req.headers["razorpay-signature"];
+  //console.log('razorpay wh req.rawBody', req.rawBody);
+  //console.log('razorpay wh req.body', req.body);
 
-    let event;
-    try {
-        const razorpayProviderService = req.scope.resolve("pp_razorpay");
-        event = razorpayProviderService.constructWebhookEvent(
-            req.body,
-            signature
-        );
-    } catch (err) {
-        res.status(400).send(`Webhook Error: ${err.message}`);
-        return;
-    }
+  const webhookSignature = req.headers["x-razorpay-signature"];
 
-    const paymentIntent = event.data.object;
+  const webhookSecret = process.env.RAZORPAY_WEBHOOK_SECRET;
 
-    const cartService = req.scope.resolve("cartService");
-    const orderService = req.scope.resolve("orderService");
+  const validationResponse = validateWebhookSignature(req.rawBody, webhookSignature, webhookSecret);
 
-    const cartId = paymentIntent.metadata.cart_id;
-    const order = await orderService
-        .retrieveByCartId(cartId)
-        .catch(() => undefined);
+  //return if validation fails
+  if (!validationResponse) {
+    return;
+  }
 
-    // handle payment intent events
-    switch (event.type) {
-        case "payment_intent.succeeded":
-            if (order && order.payment_status !== "captured") {
-                await orderService.capturePayment(order.id);
-            }
-            break;
-        // case "payment_intent.canceled":
-        //  if (order) {
-        //    await orderService.update(order._id, {
-        //      status: "canceled",
-        //    })
-        //  }
-        //  break
-        case "payment_intent.payment_failed":
-            // TODO: Not implemented yet
-            break;
-        case "payment_intent.amount_capturable_updated":
-            if (!order) {
-                await cartService.setPaymentSession(cartId, "razorpay");
-                await cartService.authorizePayment(cartId);
-                await orderService.createFromCart(cartId);
-            }
-            break;
-        default:
-            res.sendStatus(204);
-            return;
-    }
+  const event = req.body.event;
 
-    res.sendStatus(200);
+  const cartId = req.body.payload.payment.entity.notes.cart_id;
+
+  //const razorpayProviderService = req.scope.resolve('pp_razorpay');
+  const orderService = req.scope.resolve("orderService");
+
+  const order = await orderService.retrieveByCartId(cartId).catch(() => undefined);
+
+  // console.log('event', event);
+  // console.log('order', order);
+
+  switch (event) {
+    // payment authorization is handled in checkout flow. webhook not needed
+    // case 'payment.authorized':
+    //   break
+
+    case "payment.failed":
+      //TODO: notify customer of failed payment
+      if (order) {
+        await orderService.update(order._id, {
+          status: "requires_action",
+        });
+      };
+      break
+
+    //Order is not yet created in Medusa when webhook fires the first time.
+    //Therefore we send 404 response to trigger Razorpay retry
+    case "payment.captured":
+      if (order && order.payment_status !== "captured") {
+        await orderService.capturePayment(order.id);
+      } else {
+        return res.sendStatus(404);
+      }
+      break
+
+    default:
+      res.sendStatus(204);
+      return
+  }
+
+  res.sendStatus(200);
 };
+
+
+// req.body = {
+//   entity: 'event',
+//   account_id: 'acc_LRKR9N2gBC0ezZ',
+//   event: 'payment.authorized',
+//   contains: ['payment'],
+//   payload: {
+//     payment: {
+//       entity: {
+//         id: 'pay_LUahpVBO47saCl',
+//         entity: 'payment',
+//         amount: 214900,
+//         currency: 'INR',
+//         status: 'authorized',
+//         order_id: 'order_LUahZlqYrBboBZ',
+//         invoice_id: null,
+//         international: false,
+//         method: 'card',
+//         amount_refunded: 0,
+//         refund_status: null,
+//         captured: false,
+//         description: 'Order No: order_LUahZlqYrBboBZ',
+//         card_id: 'card_LUahpYeDtgqVRI',
+//         card: {
+//           id: 'card_LUahpYeDtgqVRI',
+//           entity: 'card',
+//           name: '',
+//           last4: '5449',
+//           network: 'MasterCard',
+//           type: 'credit',
+//           issuer: 'UTIB',
+//           international: false,
+//           emi: false,
+//           sub_type: 'consumer',
+//           token_iin: null,
+//         },
+//         bank: null,
+//         wallet: null,
+//         vpa: null,
+//         email: 'abc@xyz.com',
+//         contact: '+91XXXXXXXXXX',
+//         notes: {
+//           cart_id: 'cart_01GW4S0F9KQK414ZEFH4NTNYJV',
+//           customer: 'cust_LRQCbsXDFTy0Mk',
+//         },
+//         fee: null,
+//         tax: null,
+//         error_code: null,
+//         error_description: null,
+//         error_source: null,
+//         error_step: null,
+//         error_reason: null,
+//         acquirer_data: {
+//           auth_code: '377689',
+//         },
+//         created_at: 1679492688,
+//       },
+//     },
+//   },
+//   created_at: 1679492691,
+// }

--- a/src/services/razorpay-provider.js
+++ b/src/services/razorpay-provider.js
@@ -51,8 +51,6 @@ class RazorpayProviderService extends PaymentService {
             .createHmac("sha256", this.options_.api_key_secret)
             .update(body.toString())
             .digest("hex");
-        //                             console.log("sig received " ,razorpay_signature);
-        //                             console.log("sig generated " ,expectedSignature);
         return expectedSignature === razorpay_signature;
     }
 
@@ -64,6 +62,7 @@ class RazorpayProviderService extends PaymentService {
      * @return {Promise<PaymentSessionStatus>} the status of the order
      */
     async getStatus(paymentData) {
+        console.log("paymentData", paymentData)
         try {
         const { razorpay_order_id, razorpay_payment_id, razorpay_signature } = paymentData.notes;
 
@@ -88,7 +87,6 @@ class RazorpayProviderService extends PaymentService {
             case 'failed':
                 medusaStatus = 'error';
                 break
-
             default:
                 medusaStatus = 'pending';
                 break
@@ -377,7 +375,6 @@ class RazorpayProviderService extends PaymentService {
         try {
             let result = {};
 
-            // razorpay_payment_id: 'pay_JE243QWSepvqeH', razorpay_order_id: 'order_JE217mxaUTILbJ', razorpay_signature: '28021fc7955db5841a386c95c5186e98fb6d529b8196cb195af17af22da0e4fa'
             if (update.razorpay_payment_id) {
                 result = this.razorpay_.orders.edit(sessionData.id, {
                     notes: {


### PR DESCRIPTION
After a successful payment, we update the payment session's data using the ```updatePaymentData``` with the following values we get back from razorpay -
```
{
  "razorpay_payment_id": "pay_XXXXXXXXXX",
  "razorpay_order_id": "order_XXXXXXXXXX",
  "razorpay_signature": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
}
```

The second-last mandatory step in Razorpay's checkout flow requires signature verification using the above data. This step is currently missing in the ```authorizePayment``` method of the plugin.
(https://razorpay.com/docs/payments/payment-gateway/web-integration/standard/build-integration/#15-verify-payment-signature)

Also, the ```authorizePayment``` method is currently fetching from Razorpay's ORDER API via ```getStatus``` method

![orders-payment-flow](https://user-images.githubusercontent.com/74895639/226873564-8ec47d89-c3ed-4164-8086-c1eaea762ee8.png)

I think the ```getStatus``` method should first verify the signature, fetch from Razorpay's PAYMENT API instead of ORDERS API and then set the medusa status accordingly.

Let me know if this is the right approach or not